### PR TITLE
Implement script-based restart method

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -1,5 +1,5 @@
 # Common configuration for acme_vault
-# 
+#
 
 class acme_vault::common (
     $user               = $::acme_vault::params::user,
@@ -17,12 +17,13 @@ class acme_vault::common (
 ) inherits acme_vault::params {
 
     $common_bashrc_template = @(END)
-export PATH=$HOME:$PATH
-export VAULT_BIN=<%= @vault_bin %>
-export VAULT_TOKEN=<%= @vault_token %>
-export VAULT_ADDR=<%= @vault_addr %>
-export VAULT_PREFIX=<%= @vault_prefix %>
-END
+    export PATH=$HOME:$PATH
+    export VAULT_BIN=<%= @vault_bin %>
+    export VAULT_TOKEN=<%= @vault_token %>
+    export VAULT_ADDR=<%= @vault_addr %>
+    export VAULT_PREFIX=<%= @vault_prefix %>
+    | END
+
     # create acme_vault user
     user { $user:
       ensure     => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,16 +26,13 @@ class acme_vault::params {
     $acme_repo_path = "${home_dir}/acme.sh"
     $acme_script    = "${acme_repo_path}/acme.sh"
 
-    # lexicon 
-    $lexicon_provider   = undef 
-    $lexicon_username   = undef 
-    $lexicon_token      = undef 
+    # lexicon
+    $lexicon_provider   = undef
+    $lexicon_username   = undef
+    $lexicon_token      = undef
 
     # settings for deploy
-
-    $cert_destination_path = '/etc/acme/'
-
-    $restart         = false
-    $restart_command = 'echo restart!'
-
+    $cert_destination_path = '/etc/acme'
+    $deploy_scripts        = "${cert_destination_path}/deploy.d"
+    $restart_method        = "for f in ${deploy_scripts}/*.sh; do \"\$f\"; done"
 }


### PR DESCRIPTION
I've implemented a way to run arbitrary scripts after a successful acme deploy for applications to reload with new certificates.